### PR TITLE
Add support for managing components

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,3 @@
+GitPython=2.1.9
+PyYAML==3.1.2
+schema==0.6.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+GitPython
+PyYAML
+schema

--- a/rpc_component/LICENSE.txt
+++ b/rpc_component/LICENSE.txt
@@ -1,0 +1,13 @@
+Copyright 2018, Rackspace US, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/rpc_component/rpc_component/component.py
+++ b/rpc_component/rpc_component/component.py
@@ -1,0 +1,560 @@
+#!/usr/bin/env python3
+
+import argparse
+from copy import deepcopy
+from itertools import takewhile
+from operator import eq, ge, gt, le, lt, ne
+import os
+import re
+import sys
+from tempfile import TemporaryDirectory
+
+import git
+from schema import SchemaError
+import yaml
+
+from rpc_component.schemata import (
+    constraint_key, component_metadata_schema, component_requirements_schema,
+    component_schema, branch_constraint_regex, branch_constraints_schema,
+    repo_url_schema, version_constraint_regex, version_id_schema,
+    version_sha_schema
+)
+
+METADATA_FILENAME = "component_metadata.yml"
+REQUIREMENTS_FILENAME = "component_requirements.yml"
+
+
+class ComponentError(Exception):
+    pass
+
+
+def load_data(filepath, schema):
+    try:
+        with open(filepath) as f:
+            raw_data = yaml.safe_load(f)
+    except FileNotFoundError:
+        data = None
+    else:
+        data = schema.validate(raw_data)
+
+    return data
+
+
+def save_data(filepath, data, schema, old_filepath=None):
+    validated_data = schema.validate(data)
+    with open(filepath, "w") as f:
+        yaml.dump(validated_data, f, default_flow_style=False)
+
+    if old_filepath:
+        os.remove(old_filepath)
+
+
+def load_component(name, directory):
+    filename = "{name}.yml".format(name=name)
+    filepath = os.path.join(directory, filename)
+
+    return load_data(filepath, component_schema)
+
+
+def save_component(component, directory, old_component_name=None):
+    filename = "{name}.yml".format(name=component["name"])
+    filepath = os.path.join(directory, filename)
+
+    if old_component_name:
+        old_filename = "{name}.yml".format(name=old_component_name)
+        old_filepath = os.path.join(directory, old_filename)
+    else:
+        old_filepath = None
+
+    save_data(filepath, component, component_schema, old_filepath)
+
+
+def load_metadata(directory):
+    filepath = os.path.join(directory, METADATA_FILENAME)
+
+    return load_data(filepath, component_metadata_schema)
+
+
+def save_metadata(metadata, directory):
+    filepath = os.path.join(directory, METADATA_FILENAME)
+
+    save_data(filepath, metadata, component_metadata_schema)
+
+
+def load_requirements(directory):
+    filepath = os.path.join(directory, REQUIREMENTS_FILENAME)
+
+    return load_data(filepath, component_requirements_schema)
+
+
+def save_requirements(requirements, directory):
+    filepath = os.path.join(directory, REQUIREMENTS_FILENAME)
+
+    save_data(filepath, requirements, component_requirements_schema)
+
+
+def add_component(name, repo_url, is_product):
+    component = {
+        "name": name,
+        "repo_url": repo_url,
+        "is_product": is_product,
+        "releases": [],
+    }
+
+    return component_schema.validate(component)
+
+
+def update_component(existing, name=None, repo_url=None, is_product=None):
+    component = deepcopy(existing)
+    new = {
+        k: v
+        for k, v in (
+            ("name", name),
+            ("repo_url", repo_url),
+            ("is_product", is_product)
+        )
+        if v is not None
+    }
+
+    component.update(**new)
+
+    return component_schema.validate(component)
+
+
+def update_releases(component, series_name, version, sha):
+    component = deepcopy(component)
+    release = {
+        "version": version,
+        "sha": sha,
+    }
+
+    for r in component["releases"]:
+        if r["series"] == series_name:
+            series_versions = r["versions"]
+            break
+    else:
+        series_versions = []
+        component["releases"].append(
+            {
+                "series": series_name,
+                "versions": series_versions,
+            }
+        )
+
+    series_versions.append(release)
+
+    return component_schema.validate(component)
+
+
+def set_dependency(existing, name, constraints=None):
+    if existing:
+        dependencies = deepcopy(existing)
+    else:
+        dependencies = {"dependencies": []}
+
+    for dependency in dependencies["dependencies"]:
+        if dependency["name"] == name:
+            dependency["constraints"] = constraints
+            break
+    else:
+        dependencies["dependencies"].append(
+            {
+                "name": name,
+                "constraints": constraints,
+            }
+        )
+
+    return component_metadata_schema.validate(dependencies)
+
+
+def build_constraint_checker(constraints):
+    op_map = {
+        "==": eq,
+        "!=": ne,
+        ">=": ge,
+        "<=": le,
+        ">": gt,
+        "<": lt,
+    }
+
+    def check_constraint(fn, constraint):
+        c_key = tuple(
+            takewhile(
+                lambda x: x is not None,
+                constraint_key({"version": constraint})
+            )
+        )
+
+        def inner(version):
+            return fn(
+                constraint_key({"version": version})[:len(c_key)],
+                c_key
+            )
+        return inner
+
+    checks = []
+    for constraint in constraints:
+        constraint_match = re.match(version_constraint_regex, constraint)
+        checks.append(
+            check_constraint(
+                op_map[constraint_match.group("comparison_operator")],
+                constraint_match.group("version"),
+            )
+        )
+
+    return lambda v: all(c(v) for c in checks)
+
+
+def requirement_from_version_constraints(component, constraints):
+    meets_constraints = build_constraint_checker(constraints)
+    versions = reversed(
+        [
+            version
+            for series in component["releases"]
+            for version in series["versions"]
+        ]
+    )
+    for version in versions:
+        if meets_constraints(version["version"]):
+            requirement = {
+                "name": component["name"],
+                "ref": version["version"],
+                "ref_type": "tag",
+                "repo_url": component["repo_url"],
+                "sha": version["sha"],
+                "version": version["version"],
+            }
+            break
+    else:
+        raise Exception(
+            (
+                "The component '{c_name}' has no version matching the "
+                "constraints '{cs}'."
+            ).format(c_name=component["name"], cs=constraints)
+        )
+
+    return requirement
+
+
+def requirement_from_branch_constraints(component, constraints):
+    constraint = constraints.pop()
+    assert len(constraints) == 0
+
+    constraint_match = re.match(branch_constraint_regex, constraint)
+    branch_name = constraint_match.group("branch_name")
+    with TemporaryDirectory() as tmp_dir:
+        repo = git.Repo.clone_from(
+            component["repo_url"], tmp_dir, branch=branch_name
+        )
+        sha = repo.head.commit.hexsha
+
+    requirement = {
+        "name": component["name"],
+        "ref": branch_name,
+        "ref_type": "branch",
+        "repo_url": component["repo_url"],
+        "sha": sha,
+        "version": None
+    }
+
+    return requirement
+
+
+def update_requirements(metadata, component_dir):
+    requirements = {"dependencies": []}
+    for dependency in metadata["dependencies"]:
+        component = load_component(dependency["name"], component_dir)
+        if not component:
+            raise ComponentError(
+                "Dependency '{name}' does not exist.".format(
+                    name=dependency["name"],
+                )
+            )
+        constraints = dependency["constraints"]
+        try:
+            branch_constraints_schema.validate(constraints)
+        except SchemaError:
+            requirement = requirement_from_version_constraints(
+                component,
+                constraints
+            )
+        else:
+            requirement = requirement_from_branch_constraints(
+                component,
+                constraints
+            )
+
+        requirements["dependencies"].append(requirement)
+
+    return component_requirements_schema.validate(requirements)
+
+
+def download_requirements(requirements, dl_base_dir):
+    for requirement in requirements:
+        repo_dir = os.path.join(dl_base_dir, requirement["name"])
+        try:
+            repo = git.Repo(repo_dir)
+        except git.exc.NoSuchPathError:
+            repo = git.Repo.clone_from(requirement["repo_url"], repo_dir)
+        else:
+            repo.remote("origin").fetch()
+
+        repo.head.reference = repo.commit(requirement["sha"])
+        repo.head.reset(index=True, working_tree=True)
+
+
+def update_releases_repo(repo_url):
+    repo_dir = os.path.expanduser("~/.rpc_component/releases")
+    try:
+        repo = git.Repo(repo_dir)
+    except git.exc.NoSuchPathError:
+        os.makedirs(repo_dir, exist_ok=True)
+        repo = git.Repo.clone_from(repo_url, repo_dir, branch="master")
+    else:
+        repo.head.reset(index=True, working_tree=True)
+        repo.heads.master.checkout()
+        repo.remote("origin").pull()
+
+    return repo_dir
+
+
+def commit_changes(repo_dir, message):
+    repo = git.Repo(repo_dir)
+    repo.git.add(all=True)
+    repo.git.commit(message=message)
+
+
+def parse_args(args):
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--releases-dir",
+        help=(
+            "Path to releases repo. If not specified, it is cloned from "
+            "`--releases-repo`."
+        ),
+    )
+    parser.add_argument(
+        "--releases-repo",
+        default="https://github.com/rcbops/releases",
+        help=(
+                "The repository to clone if `--releases-dir` is not specified "
+                "and no previous clone exists."
+        ),
+    )
+
+    subparsers = parser.add_subparsers(dest="subparser")
+    subparsers.required = True
+
+    c_parser = subparsers.add_parser("component")
+    c_parser.add_argument(
+        "--component-name",
+        required=True,
+        help="The component name.",
+    )
+
+    c_subparser = c_parser.add_subparsers(dest="component_subparser")
+    c_subparser.required = True
+
+    ca_parser = c_subparser.add_parser("add")
+    ca_parser.add_argument(
+        "--repo-url",
+        type=repo_url_schema.validate,
+        required=True,
+        help="Component repository URL.",
+    )
+    ca_parser.add_argument("--is-product", action="store_true", default=False)
+
+    cu_parser = c_subparser.add_parser("update")
+    cu_parser.add_argument(
+        "--repo-url",
+        type=repo_url_schema.validate,
+        required=True,
+        help="Component repository URL.",
+    )
+    cu_parser.add_argument("--is-product", action="store_true", default=False)
+    cu_parser.add_argument(
+        "--new-name",
+        help="Used to change the name of a component.",
+    )
+
+    r_parser = subparsers.add_parser("release")
+    r_parser.add_argument(
+        "--component-name",
+        required=True,
+        help="The component name.",
+    )
+
+    r_parser.add_argument(
+        "--version",
+        type=version_id_schema.validate,
+        required=True,
+        help="The version identifier for the new release, e.g. 1.0.0.",
+    )
+    r_parser.add_argument(
+        "--sha",
+        type=version_sha_schema.validate,
+        required=True,
+        help="The hash of the commit to be tagged with the specified version.",
+    )
+    r_parser.add_argument(
+        "--series-name",
+        required=True,
+        help="The name of the major release to which the version belongs.",
+    )
+
+    dep_parser = subparsers.add_parser("dependency")
+    dep_parser.add_argument("--dependency-dir", default="./")
+
+    dep_subparsers = dep_parser.add_subparsers(dest="dependency_subparser")
+    dep_subparsers.required = True
+
+    req_parser = dep_subparsers.add_parser(
+        "update-requirements",
+        help=(
+            "Generate a list of dependency requirements, pinned to specific "
+            "versions/commits."
+        ),
+    )
+
+    sd_parser = dep_subparsers.add_parser("set-dependency")
+    sd_parser.add_argument(
+        "--name",
+        required=True,
+        help="The name of the component dependency.",
+    )
+    sd_parser.add_argument(
+        "--constraint",
+        action="append",
+        dest="constraints",
+        help=(
+            "A constraint limits the requirements generated from dependencies "
+            "to specific versions or branches."
+        ),
+    )
+
+    dl_parser = dep_subparsers.add_parser("download-requirements")
+    dl_parser.add_argument("--download-dir", default="./")
+
+    return vars(parser.parse_args(args))
+
+
+def main():
+    raw_args = sys.argv[1:]
+    try:
+        kwargs = parse_args(raw_args)
+
+        subparser = kwargs.pop("subparser")
+
+        releases_repo = kwargs.pop("releases_repo")
+        releases_dir = os.path.expanduser(kwargs.pop("releases_dir") or "")
+        if not releases_dir:
+            releases_dir = update_releases_repo(repo_url=releases_repo)
+
+        components_dir = os.path.join(releases_dir, "components")
+        os.makedirs(components_dir, exist_ok=True)
+
+        if subparser == "component":
+            component_name = kwargs.pop("component_name")
+            existing_component = load_component(component_name, components_dir)
+
+            component_subparser = kwargs.pop("component_subparser")
+            if component_subparser == "add":
+                if existing_component:
+                    raise ComponentError("The component already exists.")
+                updated_component = add_component(
+                    name=component_name, **kwargs
+                )
+            elif component_subparser == "update":
+                if not existing_component:
+                    raise ComponentError(
+                        "Component '{name}' does not exist.".format(
+                            name=component_name,
+                        )
+                    )
+                new_component_name = kwargs["new_name"]
+                updated_component = update_component(
+                    existing_component, name=new_component_name, **kwargs
+                )
+            else:
+                raise ComponentError(
+                    "The component subparser '{sp}' is not recognised.".format(
+                        sp=subparser,
+                    )
+                )
+
+            if updated_component != existing_component:
+                if existing_component:
+                    if updated_component["name"] != existing_component["name"]:
+                        old_name = existing_component["name"]
+                    else:
+                        old_name = None
+                else:
+                    old_name = None
+                save_component(updated_component, components_dir, old_name)
+
+                msg = "{change} component {name}".format(
+                    change=component_subparser.capitalize(),
+                    name=updated_component["name"],
+                )
+
+                commit_changes(releases_dir, msg)
+        elif subparser == "release":
+            component_name = kwargs.pop("component_name")
+            existing_component = load_component(component_name, components_dir)
+            if not existing_component:
+                raise ComponentError(
+                    "Component '{name}' does not exist.".format(
+                        name=component_name,
+                    )
+                )
+
+            updated_component = update_releases(existing_component, **kwargs)
+
+            if updated_component != existing_component:
+                save_component(updated_component, components_dir)
+                msg = "Add component {name} release {version}".format(
+                    name=updated_component["name"],
+                    version=kwargs["version"],
+                )
+
+                commit_changes(releases_dir, msg)
+        elif subparser == "dependency":
+            dependency_dir = kwargs.pop("dependency_dir")
+            metadata = load_metadata(dependency_dir)
+
+            dependency_subparser = kwargs.pop("dependency_subparser")
+            if dependency_subparser == "set-dependency":
+                data = set_dependency(metadata, **kwargs)
+                if data != metadata:
+                    save_metadata(data, dependency_dir)
+                    msg = "Set component dependency {name}".format(
+                        name=kwargs["name"],
+                    )
+
+                    commit_changes(dependency_dir, msg)
+            elif dependency_subparser == "update-requirements":
+                requirements = update_requirements(metadata, components_dir)
+                save_requirements(requirements, dependency_dir)
+                msg = "Update component dependency requirements"
+                commit_changes(dependency_dir, msg)
+            elif dependency_subparser == "download-requirements":
+                requirements = load_requirements(dependency_dir)
+                download_requirements(
+                    requirements["dependencies"], kwargs["download_dir"]
+                )
+        else:
+            raise ComponentError(
+                "The subparser '{sp}' is not recognised.".format(sp=subparser)
+            )
+    except SchemaError as e:
+        error_message = e.code
+    except ComponentError as e:
+        error_message = e
+    else:
+        error_message = None
+    sys.exit(error_message)
+
+
+if __name__ == "__main__":
+    main()

--- a/rpc_component/setup.py
+++ b/rpc_component/setup.py
@@ -1,0 +1,14 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='rpc_component',
+    version='0.0.0',
+    description='Tools for managing RPC components.',
+    install_requires=['GitPython', 'PyYAML', 'schema'],
+    packages=find_packages(),
+    entry_points={
+        'console_scripts': [
+            'component=rpc_component.component:main',
+        ],
+    },
+)

--- a/rpc_component/test_component.py
+++ b/rpc_component/test_component.py
@@ -1,0 +1,81 @@
+import unittest
+
+import rpc_component.component as c
+import rpc_component.schemata as schemata
+
+
+class TestUpdateRequirements(unittest.TestCase):
+
+    def test_requirement_from_version_constraints(self):
+        component = {
+            "name": "component0",
+            "repo_url": "https://github.com/rcbops/example-component0",
+            "is_product": False,
+            "releases": [
+                {
+                    "series": "first",
+                    "versions": [
+                        {
+                            "version": "0.0.1",
+                            "sha": "0000000000000000000000000000000000000000",
+                        },
+                        {
+                            "version": "1.0.0",
+                            "sha": "0000000000000000000000000000000000000001",
+                        },
+                        {
+                            "version": "1.0.1",
+                            "sha": "0000000000000000000000000000000000000002",
+                        },
+                        {
+                            "version": "1.1.0",
+                            "sha": "0000000000000000000000000000000000000003",
+                        },
+                        {
+                            "version": "1.1.1",
+                            "sha": "0000000000000000000000000000000000000004",
+                        },
+                        {
+                            "version": "2.0.0-alpha.1",
+                            "sha": "0000000000000000000000000000000000000005",
+                        },
+                        {
+                            "version": "2.0.0-beta.1",
+                            "sha": "0000000000000000000000000000000000000006",
+                        },
+                        {
+                            "version": "2.0.0-beta.2",
+                            "sha": "0000000000000000000000000000000000000007",
+                        },
+                        {
+                            "version": "2.0.0",
+                            "sha": "0000000000000000000000000000000000000008",
+                        },
+                        {
+                            "version": "10.0.0",
+                            "sha": "0000000000000000000000000000000000000009",
+                        },
+                    ],
+                },
+            ],
+        }
+        self.assertTrue(schemata.component_schema.validate(component))
+        constraints_test_cases = (
+            {"constraints": [], "expected_version": "10.0.0"},
+            {"constraints": ["version<10.0.0"], "expected_version": "2.0.0"},
+            {"constraints": ["version<2"], "expected_version": "1.1.1"},
+            {"constraints": ["version<1.1"], "expected_version": "1.0.1"},
+            {"constraints": ["version<=1.1"], "expected_version": "1.1.1"},
+            {
+                "constraints": ["version<2.0.0-beta.1"],
+                "expected_version": "2.0.0-alpha.1"
+            },
+        )
+        for test_case in constraints_test_cases:
+            calculated_requirement = c.requirement_from_version_constraints(
+                component, test_case["constraints"]
+            )
+            self.assertEqual(
+                test_case["expected_version"],
+                calculated_requirement["version"]
+            )

--- a/rpc_component/test_schemata.py
+++ b/rpc_component/test_schemata.py
@@ -1,0 +1,229 @@
+import unittest
+
+import rpc_component.schemata as schemata
+
+
+sorted_versions = [
+    {
+        "version": "0.0.1",
+        "sha": "0000000000000000000000000000000000000000",
+    },
+    {
+        "version": "1.0.0",
+        "sha": "0000000000000000000000000000000000000001",
+    },
+    {
+        "version": "1.0.1",
+        "sha": "0000000000000000000000000000000000000002",
+    },
+    {
+        "version": "1.1.0",
+        "sha": "0000000000000000000000000000000000000003",
+    },
+    {
+        "version": "1.1.1",
+        "sha": "0000000000000000000000000000000000000004",
+    },
+    {
+        "version": "2.0.0-alpha.1",
+        "sha": "0000000000000000000000000000000000000005",
+    },
+    {
+        "version": "2.0.0-beta.1",
+        "sha": "0000000000000000000000000000000000000006",
+    },
+    {
+        "version": "2.0.0-beta.2",
+        "sha": "0000000000000000000000000000000000000007",
+    },
+    {
+        "version": "2.0.0",
+        "sha": "0000000000000000000000000000000000000008",
+    },
+    {
+        "version": "10.0.0",
+        "sha": "0000000000000000000000000000000000000009",
+    },
+]
+
+unsorted_versions = [
+    {
+        "version": "1.1.1",
+        "sha": "0000000000000000000000000000000000000004",
+    },
+    {
+        "version": "1.0.0",
+        "sha": "0000000000000000000000000000000000000001",
+    },
+    {
+        "version": "2.0.0-beta.1",
+        "sha": "0000000000000000000000000000000000000006",
+    },
+    {
+        "version": "0.0.1",
+        "sha": "0000000000000000000000000000000000000000",
+    },
+    {
+        "version": "1.0.1",
+        "sha": "0000000000000000000000000000000000000002",
+    },
+    {
+        "version": "2.0.0-beta.2",
+        "sha": "0000000000000000000000000000000000000007",
+    },
+    {
+        "version": "1.1.0",
+        "sha": "0000000000000000000000000000000000000003",
+    },
+    {
+        "version": "10.0.0",
+        "sha": "0000000000000000000000000000000000000009",
+    },
+    {
+        "version": "2.0.0",
+        "sha": "0000000000000000000000000000000000000008",
+    },
+    {
+        "version": "2.0.0-alpha.1",
+        "sha": "0000000000000000000000000000000000000005",
+    },
+]
+
+
+class TestValidationFunctions(unittest.TestCase):
+    def test_sorted_versions(self):
+        self.assertNotEqual(sorted_versions, unsorted_versions)
+        self.assertEqual(
+            sorted_versions,
+            schemata.sorted_versions(unsorted_versions)
+        )
+
+    def test_is_sorted_versions(self):
+        self.assertTrue(schemata.is_sorted_versions(sorted_versions))
+        self.assertFalse(schemata.is_sorted_versions(unsorted_versions))
+
+    def test_is_value_unique(self):
+        unique = [
+            {"key": 1},
+            {"key": 2},
+            {"key": 3},
+        ]
+        not_unique = [
+            {"key": 1},
+            {"key": 1},
+            {"key": 3},
+        ]
+        self.assertTrue(schemata.is_value_unique("key")(unique))
+        self.assertFalse(schemata.is_value_unique("key")(not_unique))
+
+
+class TestSchemaValidation(unittest.TestCase):
+    def test_component_requirements_schema(self):
+        minimal = {"dependencies": []}
+        with_deps = {
+            "dependencies": [
+                {
+                    "name": "dep0",
+                    "ref": "1.0.0",
+                    "ref_type": "tag",
+                    "repo_url": "https://github.com/rcbops/example-dep-0",
+                    "sha": "0000000000000000000000000000000000000002",
+                    "version": "1.0.0",
+                },
+                {
+                    "name": "dep1",
+                    "ref": "some-branch",
+                    "ref_type": "branch",
+                    "repo_url": "https://github.com/rcbops/example-dep-1",
+                    "sha": "0000000000000000000000000000000000001000",
+                    "version": None,
+                },
+            ]
+        }
+
+        self.assertTrue(
+            schemata.component_requirements_schema.validate(minimal)
+        )
+        self.assertTrue(
+            schemata.component_requirements_schema.validate(with_deps)
+        )
+
+    def test_component_metadata_schema(self):
+        minimal = {"dependencies": []}
+        with_deps = {
+            "dependencies": [
+                {
+                    "name": "dep0",
+                    "constraints": ["version<2.0.0"],
+                },
+                {
+                    "name": "dep1",
+                    "constraints": ["branch==some-branch"],
+                },
+                {
+                    "name": "dep2",
+                    "constraints": [],
+                },
+            ]
+        }
+
+        self.assertTrue(
+            schemata.component_metadata_schema.validate(minimal)
+        )
+        self.assertTrue(
+            schemata.component_metadata_schema.validate(with_deps)
+        )
+
+    def test_component_schema(self):
+        minimal = {
+            "name": "component0",
+            "repo_url": "https://github.com/rcbops/example-component0",
+            "is_product": False,
+            "releases": [],
+        }
+        with_release = {
+            "name": "component1",
+            "repo_url": "https://github.com/rcbops/example-component1",
+            "is_product": False,
+            "releases": [
+                {
+                    "series": "first",
+                    "versions": [
+                        {
+                            "version": "1.0.0",
+                            "sha": "0000000000000000000000000000000000000000",
+                        },
+                    ],
+                },
+            ],
+        }
+
+        self.assertTrue(
+            schemata.component_schema.validate(minimal)
+        )
+        self.assertTrue(
+            schemata.component_schema.validate(with_release)
+        )
+
+    def test_constraints_schema(self):
+        minimal = []
+        valid_version_constraints = [
+            "version<2",
+            "version<1.1",
+            "version<1.1.0",
+            "version<=1.1.0",
+            "version==1.1.0",
+            "version!=1.1.0",
+            "version>1.1.0",
+            "version>=1.1.0",
+        ]
+        valid_branch_constraints = [
+            "branch==test",
+        ]
+        self.assertEqual([], schemata.constraints_schema.validate(minimal))
+        self.assertTrue(
+            schemata.constraints_schema.validate(valid_version_constraints)
+        )
+        self.assertTrue(
+            schemata.constraints_schema.validate(valid_branch_constraints)
+        )


### PR DESCRIPTION
This change adds the tool `component` for managing the component
information stored in the releases repository as well as that located in
the component repositories.
    
The tools includes support for the following:
    - registering a component
    - updating a component entry
    - adding a new release
    - tracking component dependencies
    - generating pinned component requirements from dependency constraints
    - downloading requirements
