### PR TITLE
RE-1317 Add update validation

### DIFF
--- a/rpc_component/rpc_component/schemata.py
+++ b/rpc_component/rpc_component/schemata.py
@@ -48,6 +48,29 @@ version_schema = Schema(
         "sha": version_sha_schema,
     },
 )
+comparison_added_version_schema = Schema(
+    And(
+        {
+            And(str, len): {
+                "added": {
+                    "releases": And(
+                        [
+                            {
+                                "versions": And(
+                                    [version_schema],
+                                    lambda vs: len(vs) == 1,
+                                ),
+                            }
+                        ],
+                        lambda rs: len(rs) == 1,
+                    )
+                },
+                "deleted": {},
+            }
+        },
+        lambda cs: len(cs) == 1,
+    )
+)
 
 repo_url_schema = Regex(r"^https://github.com/.+")
 


### PR DESCRIPTION
The release process needs to be able to recognise what changes have been
made to components in a pull request and whether or not they are valid.
This commit extends the `component` tool to support validating a request
for the release of a new version of a component.

To simply compare the differences between to versions:
component compare --from from-SHA --to to-SHA

To check that the differences constitute only a new version:
component compare --from from-SHA --to to-SHA --verify version