### PR TITLE
RE-1317 Extend commit comparison to return record

### DIFF
--- a/rpc_component/rpc_component/schemata.py
+++ b/rpc_component/rpc_component/schemata.py
@@ -97,6 +97,18 @@ constraints_schema = Or(
     branch_constraints_schema,
 )
 
+component_single_version_schema = Schema(
+    {
+        "name": And(str, len),
+        "repo_url": repo_url_schema,
+        "is_product": bool,
+        "release": {
+            "series": And(str, len),
+            "version": version_schema,
+        },
+    }
+)
+
 component_schema = Schema(
     {
         "name": And(str, len),


### PR DESCRIPTION
The comparison functionality added creates a situation whereby once it
has validated a change only added a new version, it doesn't return
sufficient information to make use of that confirmation. This change
modifies the response when `--verify version` is supplied to return the
complete component record for the version that has been added, e.g.:

$ component compare --from 1e981bf7c7861b0da0ce5d0977d47797bb2b9294^ \
                    --to 1e981bf7c7861b0da0ce5d0977d47797bb2b9294 \
                    --verify version
is_product: false
name: rpc-component-1
release:
  series: master
  version:
    sha: f14b802447c544a713de360f872cc571ac9ddb3f
    version: r1.1.1
repo_url: https://github.com/mattt416/rpc-component-1