### PR TITLE
RE-1317 Allow comparison of version on new series

### DIFF
--- a/rpc_component/rpc_component/schemata.py
+++ b/rpc_component/rpc_component/schemata.py
@@ -1,7 +1,7 @@
 from functools import partial
 import re
 
-from schema import And, Or, Regex, Schema
+from schema import And, Optional, Or, Regex, Schema
 
 
 def sorted_versions(versions):
@@ -48,6 +48,7 @@ version_schema = Schema(
         "sha": version_sha_schema,
     },
 )
+
 comparison_added_version_schema = Schema(
     And(
         {
@@ -56,6 +57,7 @@ comparison_added_version_schema = Schema(
                     "releases": And(
                         [
                             {
+                                Optional("series"): And(str, len),
                                 "versions": And(
                                     [version_schema],
                                     lambda vs: len(vs) == 1,


### PR DESCRIPTION
This change allows successful validation of a change that adds a new
version that was part of a new series.

For example:
```
$ component compare --from from-sha --to to-sha
a-component:
  added:
    releases:
    - series: first
      versions:
      - sha: some-sha
        version: 1.0.0
  deleted: {}
```

Previously this would fail because the series `first` is being added,
however with this change it succeeds.

```
$ component compare --from from-sha --to to-sha --verify version
is_product: false
name: a-component
release:
  series: first
  version:
    sha: some-sha
    version: 1.0.0
repo_url: https://github.com/mattt416/a-component
```