### PR TITLE
RE-1317 Add basic lint script

### DIFF
--- a/gating/pre_merge_check/run
+++ b/gating/pre_merge_check/run
@@ -11,11 +11,17 @@ popd
 
 component_count=0
 non_component_count=0
+# The component cli tool takes a `from` and `to` SHA. Since we don't know how
+# many commits are in the PR, we use `master` as the `from` SHA and `HEAD` as
+# the `to` SHA. This allows us to compare against the last committed commit
+# and the changes proposed in the PR.
+src_branch="master"
+pr_branch="HEAD"
 
-changes=$(git diff --pretty=format: --name-only master HEAD)
+changes=$(git diff --pretty=format: --name-only ${src_branch} ${pr_branch})
 
 for change in ${changes}; do
-  if [[ "${change}" =~ ^components/ ]]; then
+  if [[ "${change}" =~ ^"components/" ]]; then
     component_count=$(( ${component_count} + 1 ))
   else
     non_component_count=$(( ${non_component_count} + 1 ))
@@ -39,7 +45,7 @@ if [[ ${component_count} -eq 1 ]]; then
 
   ## Test 3: Check if a new component is being released
 
-  component --releases-dir . compare --from master --to HEAD --verify registration
+  component --releases-dir . compare --from ${src_branch} --to ${pr_branch} --verify registration
 
   [[ $? -ne 0 ]] \
     && { echo '[FAIL] The component registration is not valid'; fail_count=$(( ${fail_count} + 1 )); } \
@@ -47,7 +53,7 @@ if [[ ${component_count} -eq 1 ]]; then
 
   ## Test 4: Check if a component release is valid
 
-  component --releases-dir . compare --from master --to HEAD --verify version
+  component --releases-dir . compare --from ${src_branch} --to ${pr_branch} --verify version
 
   [[ $? -ne 0 ]] \
     && { echo '[FAIL] The component release is not valid'; fail_count=$(( ${fail_count} + 1 )); } \

--- a/gating/pre_merge_check/run
+++ b/gating/pre_merge_check/run
@@ -1,0 +1,65 @@
+#!/bin/bash -xeu
+
+RC=0
+
+virtualenv --python python3 .venv3
+set +x; . .venv3/bin/activate; set -x
+pip install -c constraints.txt -r requirements.txt
+pushd rpc_component
+  pip install .
+popd
+
+component_count=0
+non_component_count=0
+
+changes=$(git log --pretty=format: --name-only --no-merges -1)
+
+for change in ${changes}; do
+  if [[ "${change}" =~ "components/" ]]; then
+    component_count=$(( ${component_count} + 1 ))
+  else
+    non_component_count=$(( ${non_component_count} + 1 ))
+  fi
+done
+
+## Test 1: Check the number of components being changed at the same time
+
+[[ ${component_count} -gt 1 ]] \
+  && { echo '[FAIL] Multiple components modified in one change'; RC=1; } \
+  || echo '  [OK] Zero or one component modified in change'
+
+## Test 2: Check if a component and non-component are being changed at the same time
+
+[[ ${component_count} -gt 0 && ${non_component_count} -gt 0 ]] \
+  && { echo '[FAIL] A component and non-component change was submitted at the same time'; RC=1; } \
+  || echo '  [OK] A component and non-component change was not submitted at the same time'
+
+if [[ ${component_count} -eq 1 ]]; then
+  from=$(git log --pretty=format:%H  --no-merges -n 1 --skip 1)
+  to=$(git log --pretty=format:%H --no-merges -1)
+  fail_count=0
+
+  ## Test 3: Check if a new component is being released
+
+  component --releases-dir . compare --from ${from} --to ${to} --verify registration
+
+  [[ $? -ne 0 ]] \
+    && { echo '[FAIL] The component registration is not valid'; fail_count=$(( ${fail_count} + 1 )); } \
+    || echo '  [OK] The component registration is valid'
+
+  ## Test 4: Check if a component release is valid
+
+  component --releases-dir . compare --from ${from} --to ${to} --verify version
+
+  [[ $? -ne 0 ]] \
+    && { echo '[FAIL] The component release is not valid'; fail_count=$(( ${fail_count} + 1 )); } \
+    || echo '  [OK] The component release is valid'
+
+  ## TODO: Test 5: Check if an existing component is being modified
+
+  [[ ${fail_count} -eq 2 ]] && RC=1
+else
+  echo '[SKIP] Zero or multiple components being modified, cannot properly test component modification'
+fi
+
+exit ${RC}

--- a/gating/pre_merge_check/run
+++ b/gating/pre_merge_check/run
@@ -12,10 +12,10 @@ popd
 component_count=0
 non_component_count=0
 
-changes=$(git log --pretty=format: --name-only --no-merges -1)
+changes=$(git diff --pretty=format: --name-only master HEAD)
 
 for change in ${changes}; do
-  if [[ "${change}" =~ "components/" ]]; then
+  if [[ "${change}" =~ ^components/ ]]; then
     component_count=$(( ${component_count} + 1 ))
   else
     non_component_count=$(( ${non_component_count} + 1 ))
@@ -35,13 +35,11 @@ done
   || echo '  [OK] A component and non-component change was not submitted at the same time'
 
 if [[ ${component_count} -eq 1 ]]; then
-  from=$(git log --pretty=format:%H  --no-merges -n 1 --skip 1)
-  to=$(git log --pretty=format:%H --no-merges -1)
   fail_count=0
 
   ## Test 3: Check if a new component is being released
 
-  component --releases-dir . compare --from ${from} --to ${to} --verify registration
+  component --releases-dir . compare --from master --to HEAD --verify registration
 
   [[ $? -ne 0 ]] \
     && { echo '[FAIL] The component registration is not valid'; fail_count=$(( ${fail_count} + 1 )); } \
@@ -49,7 +47,7 @@ if [[ ${component_count} -eq 1 ]]; then
 
   ## Test 4: Check if a component release is valid
 
-  component --releases-dir . compare --from ${from} --to ${to} --verify version
+  component --releases-dir . compare --from master --to HEAD --verify version
 
   [[ $? -ne 0 ]] \
     && { echo '[FAIL] The component release is not valid'; fail_count=$(( ${fail_count} + 1 )); } \

--- a/rpc_component/rpc_component/component.py
+++ b/rpc_component/rpc_component/component.py
@@ -15,9 +15,9 @@ from schema import SchemaError
 import yaml
 
 from rpc_component.schemata import (
-    comparison_added_version_schema, constraint_key, component_metadata_schema,
-    component_requirements_schema, component_schema,
-    component_single_version_schema, branch_constraint_regex,
+    comparison_added_component_schema, comparison_added_version_schema,
+    constraint_key, component_metadata_schema, component_requirements_schema,
+    component_schema, component_single_version_schema, branch_constraint_regex,
     branch_constraints_schema, repo_url_schema, version_constraint_regex,
     version_id_schema, version_sha_schema,
 )
@@ -524,7 +524,7 @@ def parse_args(args):
     )
     com_parser.add_argument(
         "--verify",
-        choices=["version"],
+        choices=["version", "registration"],
     )
 
     return vars(parser.parse_args(args))
@@ -684,6 +684,22 @@ def main():
                         }
                     )
                     output = yaml.dump(comp_version, default_flow_style=False)
+            elif kwargs["verify"] == "registration":
+                try:
+                    comparison_added_component_schema.validate(comparison)
+                except SchemaError as e:
+                    raise ComponentError(
+                        "The changes from `{f}` to `{t}` do not represent the "
+                        "registration of a new component.\nValidation error:"
+                        "\n{e}\nChanges found:\n{c}".format(
+                            f=kwargs["from"],
+                            t=kwargs["to"],
+                            e=e,
+                            c=comparison_yaml,
+                        )
+                    )
+                else:
+                    output = comparison_yaml
             else:
                 output = comparison_yaml
 

--- a/rpc_component/rpc_component/schemata.py
+++ b/rpc_component/rpc_component/schemata.py
@@ -166,6 +166,18 @@ component_requirements_schema = Schema(
     }
 )
 
+comparison_added_component_schema = Schema(
+    And(
+        {
+            And(str, len): {
+                "added": And(component_schema),
+                "deleted": {},
+            }
+        },
+        lambda cs: len(cs) == 1,
+    )
+)
+
 
 def _version_key(version, regex=None):
     version_id = version["version"]


### PR DESCRIPTION
This commit adds a basic PR job that lint checks changes being submit
to the repo. To summarise, it:

1. Checks the number of components being changed at the same time
   (more than 1 is a problem).
2. Ensures that a component change is not happening along-side a non
   component change (components should be registered / released in
   isolation).
3. If a single component is being updated, it:
   a) Checks if it's a new component and validates the schema.
   b) Checks if it's a new version release and validates the schema.